### PR TITLE
feat: test decimal

### DIFF
--- a/ilp-client-interop-test.json
+++ b/ilp-client-interop-test.json
@@ -32,6 +32,7 @@
         ],
         "result": {
             "status": "SUCCESS",
+            "binaryBase64": "dGVzdF90YWJsZSxzeW1fY29sPXN5bV92YWwgc3RyX2NvbD0iZm9vIGJhciBiYXoiLGxvbmdfY29sPTQyaSxkb3VibGVfY29sPT0QAAAAAABARUAsYm9vbF9jb2w9dAo=",
             "line": "test_table,sym_col=sym_val str_col=\"foo bar baz\",long_col=42i,double_col=42.5,bool_col=t"
         }
     },
@@ -73,6 +74,7 @@
         ],
         "result": {
             "status": "SUCCESS",
+            "binaryBase64": "ZG91YmxlcyBkMD09EAAAAAAAAAAALGRtMD09EAAAAAAAAACALGQxPT0QAAAAAAAA8D8sZEUxMDA9PRB9w5QlrUmyVCxkMDAwMDAwMT09EI3ttaD3xrA+LGROMDAwMDAwMT09EI3ttaD3xrC+Cg==",
             "anyLines": [
                 "doubles d0=0,dm0=-0,d1=1,dE100=1E+100,d0000001=1E-06,dN0000001=-1E-06",
                 "doubles d0=0.0,dm0=-0.0,d1=1.0,dE100=1e100,d0000001=1e-6,dN0000001=-1e-6",
@@ -1639,15 +1641,57 @@
         "testName": "quote in symbol value",
         "table": "quote",
         "symbols": [
-          {
-            "name": "sym",
-            "value": "\"val\""
-          }
+            {
+                "name": "sym",
+                "value": "\"val\""
+            }
         ],
         "columns": [],
         "result": {
-          "status": "SUCCESS",
-          "line": "quote,sym=\"val\""
+            "status": "SUCCESS",
+            "line": "quote,sym=\"val\""
+        }
+    },
+    {
+        "testName": "decimal",
+        "table": "decimals",
+        "symbols": [],
+        "columns": [
+            {
+                "type": "DECIMAL",
+                "name": "zero",
+                "value": "0.0"
+            },
+            {
+                "type": "DECIMAL",
+                "name": "neg_zero",
+                "value": "-0.0"
+            },
+            {
+                "type": "DECIMAL",
+                "name": "one",
+                "value": "1.0"
+            },
+            {
+                "type": "DECIMAL",
+                "name": "large",
+                "value": "99999999999999.999"
+            },
+            {
+                "type": "DECIMAL",
+                "name": "small",
+                "value": "0.001"
+            },
+            {
+                "type": "DECIMAL",
+                "name": "neg_small",
+                "value": "-0.001"
+            }
+        ],
+        "result": {
+            "status": "SUCCESS",
+            "line": "decimals zero=0d,neg_zero=0d,one=1.0d,large=99999999999999.999d,small=0.001d,neg_small=-0.001d",
+            "binaryBase64": "ZGVjaW1hbHMgemVybz09FwEBACxuZWdfemVybz09FwEBACxvbmU9PRcBAQosbGFyZ2U9PRcDCAFjRXhdif//LHNtYWxsPT0XAwEBLG5lZ19zbWFsbD09FwMB/wo="
         }
     }
 ]

--- a/ilp-client-interop-test.json
+++ b/ilp-client-interop-test.json
@@ -1654,6 +1654,7 @@
     },
     {
         "testName": "decimal",
+        "minimumProtocolVersion": 3,
         "table": "decimals",
         "symbols": [],
         "columns": [


### PR DESCRIPTION
This PR adds a new test to validate decimal serialization in both text (v1) and binary (v2) formats.

Tandem with:
 - https://github.com/questdb/questdb/pull/6068
 - https://github.com/questdb/c-questdb-client/pull/123